### PR TITLE
feat: Add a simple index.html page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en" class="text-gray-100 bg-gray-900">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Helm Repository | GO Feature Flag</title>
+    <link rel="shortcut icon" type="image/x-icon" href="https://gofeatureflag.org/img/favicon/favicon.png">
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body>
+    <div class="w-4/5 mx-auto py-5 bg-gray-800 rounded-xl items-center mt-6">
+        <div class="mx-auto w-48 h-48 rounded-full bg-gray-700 relative border border-dashed border-gray-600">
+            <a href="https://gofeatureflag.org" target="_blank">
+                <img src="https://github.com/thomaspoignant/go-feature-flag/raw/main/gofeatureflag.svg"
+                     alt="GO Feature Flag logo"
+                     class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full pl-6"
+                />
+            </a>
+        </div>
+        <h1 class="text-center text-3xl font-mono py-3 pt-10">
+            GO Feature Flag Helm Repository
+        </h1>
+        <div class="w-3/4 mx-auto text-gray-400 mt-6 text-lg">
+            <p class="mb-2">Welcome to the GO Feature Flag Helm Repository where you can find the Helm Charts for GO Feature Flag.</p>
+            <p>If you are looking at some documentation, consider going to our <a href="https://gofeatureflag.org/docs" target="_blank" class="text-red-300 underline decoration-dotted">official documentation website</a>.</p>
+        </div>
+        <h2 class="text-center text-xl font-mono py-3 mt-12">
+            Want to use this repository?
+        </h2>
+        <p class="w-3/4 mx-auto text-center mb-2 rounded-xl bg-gray-700 p-6 text-lg font-mono">helm repo add go-feature-flag https://charts.gofeatureflag.org/</p>
+        <div class="w-3/5 mx-auto text-gray-400 text-center italic text-sm">
+            <p class="mb-2">This command will add GO Feature Flag Helm Repository to your local environment.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
# Description
Add a simple index.html page to avoid 404 when going to https://chart.gofeatureflag.org
# Closes issue(s)

Resolve #1

# Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
